### PR TITLE
Fixes for availability grids that cross UTC day boundaries

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -656,28 +656,6 @@ class AvailabilityGrid(models.Model):
         return result
 
     @property
-    def time_slots(self) -> list[str]:
-        """Return list of time slot strings from start_time to end_time by slot_duration.
-
-        Handles wrap-around past midnight (e.g. start_time=15:00, end_time=02:00).
-
-        Returns:
-            List of "HH:MM" strings for each slot in the time range.
-
-        """
-        start = datetime.strptime(self.start_time, "%H:%M")
-        end = datetime.strptime(self.end_time, "%H:%M")
-        if end <= start:
-            end += timedelta(hours=24)
-        delta = timedelta(minutes=self.slot_duration)
-        result = []
-        current = start
-        while current < end:
-            result.append(current.strftime("%H:%M"))
-            current += delta
-        return result
-
-    @property
     def response_count(self) -> int:
         """Return the number of responses for this grid.
 

--- a/apps/events/tz_utils.py
+++ b/apps/events/tz_utils.py
@@ -42,14 +42,16 @@ def convert_local_to_utc(
     local_end_time = time.fromisoformat(end_time)
 
     local_start_dt = datetime.combine(start_date, local_start_time, tzinfo=tz)
+    local_last_day_start_dt = datetime.combine(end_date, local_start_time, tzinfo=tz)
     local_end_dt = datetime.combine(end_date, local_end_time, tzinfo=tz)
 
     utc_start_dt = local_start_dt.astimezone(utc)
+    utc_last_day_start_dt = local_last_day_start_dt.astimezone(utc)
     utc_end_dt = local_end_dt.astimezone(utc)
 
     return (
         utc_start_dt.date(),
-        utc_end_dt.date(),
+        utc_last_day_start_dt.date(),
         utc_start_dt.strftime("%H:%M"),
         utc_end_dt.strftime("%H:%M"),
     )
@@ -96,7 +98,9 @@ def convert_blocked_cells_to_utc(
 
 def convert_grid_to_local(
     utc_dates: list[str],
-    utc_time_slots: list[str],
+    start_time: time,
+    end_time: time,
+    slot_duration: int,
     blocked_cells: list[dict],
     target_tz: str,
 ) -> dict:
@@ -108,6 +112,9 @@ def convert_grid_to_local(
 
     Args:
         utc_dates: List of UTC date strings ("YYYY-MM-DD").
+        start_time: First race time on each day.
+        end_time: End of race availability on each day.
+        slot_duration: Minutes per availability slot.
         utc_time_slots: List of UTC time strings ("HH:MM").
         blocked_cells: List of {"date": ..., "time": ...} dicts in UTC.
         target_tz: IANA timezone string for display.
@@ -149,13 +156,23 @@ def convert_grid_to_local(
     reverse_map: dict[str, str] = {}
 
     for d_str in utc_dates:
-        for t_str in utc_time_slots:
-            utc_dt = datetime.combine(
-                date.fromisoformat(d_str),
-                time.fromisoformat(t_str),
-                tzinfo=utc,
+        start = datetime.combine(
+            date.fromisoformat(d_str),
+            start_time,
+            tzinfo=utc,
             )
-            local_dt = utc_dt.astimezone(tz)
+        end = datetime.combine(
+            date.fromisoformat(d_str),
+            end_time,
+            tzinfo=utc,
+            )
+        if end <= start:
+            end += timedelta(days=1)
+        current = start
+        delta = timedelta(minutes=slot_duration)
+        while current < end:
+            t_str = current.strftime("%H:%M")
+            local_dt = current.astimezone(tz)
             local_d = local_dt.strftime("%Y-%m-%d")
             local_t = local_dt.strftime("%H:%M")
             local_dates_set.add(local_d)
@@ -165,6 +182,8 @@ def convert_grid_to_local(
             utc_key = f"{d_str}|{t_str}"
             cell_map[local_key] = {"date": d_str, "time": t_str}
             reverse_map[utc_key] = local_key
+
+            current += delta
 
     blocked_utc_set = {f"{c['date']}|{c['time']}" for c in blocked_cells}
     display_blocked: set[str] = set()

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -2432,32 +2432,6 @@ def _expand_utc_dates(start_date: date, end_date: date) -> list[str]:
     return out
 
 
-def _expand_time_slots(start_time: str, end_time: str, slot_duration: int) -> list[str]:
-    """Return an ordered list of ``HH:MM`` slot strings, handling midnight wrap.
-
-    Args:
-        start_time: ``HH:MM`` start of the slot range.
-        end_time: ``HH:MM`` end of the slot range (exclusive). If less than or
-            equal to ``start_time``, wraps past midnight.
-        slot_duration: Slot length in minutes.
-
-    Returns:
-        List of ``HH:MM`` strings.
-
-    """
-    start = datetime.strptime(start_time, "%H:%M")
-    end = datetime.strptime(end_time, "%H:%M")
-    if end <= start:
-        end += timedelta(hours=24)
-    delta = timedelta(minutes=slot_duration)
-    out: list[str] = []
-    cur = start
-    while cur < end:
-        out.append(cur.strftime("%H:%M"))
-        cur += delta
-    return out
-
-
 @login_required
 @team_member_required()
 @require_POST
@@ -2526,7 +2500,6 @@ def availability_preview_view(request: HttpRequest, event_pk: int, squad_pk: int
         utc_blocked = list(blocked_cells)
 
     utc_dates = _expand_utc_dates(utc_start_date, utc_end_date)
-    utc_time_slots = _expand_time_slots(utc_start_time, utc_end_time, slot_duration)
 
     # 2. Convert UTC → display timezone (preferring the user's profile tz).
     user_tz = (getattr(request.user, "timezone", "") or "").strip()
@@ -2534,7 +2507,7 @@ def availability_preview_view(request: HttpRequest, event_pk: int, squad_pk: int
     if display_tz != "UTC" and display_tz not in available_timezones():
         display_tz = "UTC"
 
-    grid_data = convert_grid_to_local(utc_dates, utc_time_slots, utc_blocked, display_tz)
+    grid_data = convert_grid_to_local(utc_dates, utc_start_time, utc_end_time, slot_duration, utc_blocked, display_tz)
 
     return JsonResponse({
         "display_dates": list(grid_data["display_dates"]),
@@ -2835,7 +2808,7 @@ def availability_respond_view(request: HttpRequest, event_pk: int, squad_pk: int
     display_tz = user_tz or grid.grid_timezone or "UTC"
     tz_is_default = not user_tz
 
-    grid_data = convert_grid_to_local(grid.dates, grid.time_slots, grid.blocked_cells, display_tz)
+    grid_data = convert_grid_to_local(grid.dates, grid.start_time, grid.end_time, grid.slot_duration, grid.blocked_cells, display_tz)
 
     # Convert existing response UTC keys → local keys
     existing_local_keys: list[str] = []
@@ -2983,7 +2956,7 @@ def availability_results_view(request: HttpRequest, event_pk: int, squad_pk: int
     display_tz = user_tz or grid.grid_timezone or "UTC"
     tz_is_default = not user_tz
 
-    grid_data = convert_grid_to_local(grid.dates, grid.time_slots, grid.blocked_cells, display_tz)
+    grid_data = convert_grid_to_local(grid.dates, grid.start_time, grid.end_time, grid.slot_duration, grid.blocked_cells, display_tz)
 
     # Re-key user IDs from UTC → local
     cell_user_ids: dict[str, list[int]] = {}


### PR DESCRIPTION
Two related but separate fixes:

If the end time is after midnight in UTC, the day after the intended end date was saved as the grid's end date, and then a whole extra day's worth of race times was added. Fix this by making "end date" the last day that contains a "start time", instead of the last day with any timeslots.

The set of timeslots was set to be the same on each UTC day when displaying the form to riders, but this isn't how the form creation UI works: it sets the set of timeslots to be the same on each local day. Make the rider display match the form creation display by iterating from start_time to end_time on each UTC day in range.

Fair warning: I did not get the dev server setup working, so I haven't run this and there could be a bug in here.