### PR TITLE
Use historical version of User model in migrations

### DIFF
--- a/apps/accounts/migrations/0013_add_is_race_ready_cached_field.py
+++ b/apps/accounts/migrations/0013_add_is_race_ready_cached_field.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 def populate_race_ready(apps, schema_editor):
     """Populate is_race_ready for existing users using the live model's calculate_race_ready()."""
-    from apps.accounts.models import User
+    User = apps.get_model('accounts', 'User')
 
     users = (
         User.objects

--- a/apps/accounts/migrations/0014_add_is_extra_verified.py
+++ b/apps/accounts/migrations/0014_add_is_extra_verified.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 def populate_extra_verified(apps, schema_editor):
     """Populate is_extra_verified for existing users using the live model's calculate_extra_verified()."""
-    from apps.accounts.models import User
+    User = apps.get_model('accounts', 'User')
 
     users = User.objects.exclude(discord_id="").exclude(discord_id__isnull=True).prefetch_related("race_ready_records")
     to_update = []


### PR DESCRIPTION
Without this, migrations don't apply later after more fields have been added.