### PR TITLE
Display same timeslots to riders as in grid creation

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -663,28 +663,6 @@ class AvailabilityGrid(models.Model):
         return result
 
     @property
-    def time_slots(self) -> list[str]:
-        """Return list of time slot strings from start_time to end_time by slot_duration.
-
-        Handles wrap-around past midnight (e.g. start_time=15:00, end_time=02:00).
-
-        Returns:
-            List of "HH:MM" strings for each slot in the time range.
-
-        """
-        start = datetime.strptime(self.start_time, "%H:%M")
-        end = datetime.strptime(self.end_time, "%H:%M")
-        if end <= start:
-            end += timedelta(hours=24)
-        delta = timedelta(minutes=self.slot_duration)
-        result = []
-        current = start
-        while current < end:
-            result.append(current.strftime("%H:%M"))
-            current += delta
-        return result
-
-    @property
     def response_count(self) -> int:
         """Return the number of responses for this grid.
 

--- a/apps/events/tz_utils.py
+++ b/apps/events/tz_utils.py
@@ -4,7 +4,7 @@ All grid data is stored as UTC. These functions convert between a local
 timezone and UTC for display and persistence.
 """
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
 
@@ -102,7 +102,9 @@ def convert_blocked_cells_to_utc(
 
 def convert_grid_to_local(
     utc_dates: list[str],
-    utc_time_slots: list[str],
+    start_time: str,
+    end_time: str,
+    slot_duration: int,
     blocked_cells: list[dict],
     target_tz: str,
 ) -> dict:
@@ -114,7 +116,9 @@ def convert_grid_to_local(
 
     Args:
         utc_dates: List of UTC date strings ("YYYY-MM-DD").
-        utc_time_slots: List of UTC time strings ("HH:MM").
+        start_time: First race time on each day ("HH:MM").
+        end_time: End of race availability on each day ("HH:MM").
+        slot_duration: Minutes per availability slot.
         blocked_cells: List of {"date": ..., "time": ...} dicts in UTC.
         target_tz: IANA timezone string for display.
 
@@ -128,24 +132,6 @@ def convert_grid_to_local(
             valid_cells: set of "local_date|local_time" keys that have a UTC counterpart
 
     """
-    if target_tz == "UTC":
-        blocked_set = {f"{c['date']}|{c['time']}" for c in blocked_cells}
-        cell_map = {}
-        reverse_map = {}
-        for d in utc_dates:
-            for t in utc_time_slots:
-                key = f"{d}|{t}"
-                cell_map[key] = {"date": d, "time": t}
-                reverse_map[key] = key
-        return {
-            "display_dates": list(utc_dates),
-            "display_time_slots": list(utc_time_slots),
-            "cell_map": cell_map,
-            "reverse_map": reverse_map,
-            "display_blocked": blocked_set,
-            "valid_cells": set(cell_map.keys()),
-        }
-
     tz = ZoneInfo(target_tz)
     utc = ZoneInfo("UTC")
 
@@ -155,13 +141,23 @@ def convert_grid_to_local(
     reverse_map: dict[str, str] = {}
 
     for d_str in utc_dates:
-        for t_str in utc_time_slots:
-            utc_dt = datetime.combine(
-                date.fromisoformat(d_str),
-                time.fromisoformat(t_str),
-                tzinfo=utc,
-            )
-            local_dt = utc_dt.astimezone(tz)
+        start = datetime.combine(
+            date.fromisoformat(d_str),
+            time.fromisoformat(start_time),
+            tzinfo=utc,
+        )
+        end = datetime.combine(
+            date.fromisoformat(d_str),
+            time.fromisoformat(end_time),
+            tzinfo=utc,
+        )
+        if end <= start:
+            end += timedelta(days=1)
+        current = start
+        delta = timedelta(minutes=slot_duration)
+        while current < end:
+            t_str = current.strftime("%H:%M")
+            local_dt = current.astimezone(tz)
             local_d = local_dt.strftime("%Y-%m-%d")
             local_t = local_dt.strftime("%H:%M")
             local_dates_set.add(local_d)
@@ -171,6 +167,8 @@ def convert_grid_to_local(
             utc_key = f"{d_str}|{t_str}"
             cell_map[local_key] = {"date": d_str, "time": t_str}
             reverse_map[utc_key] = local_key
+
+            current += delta
 
     blocked_utc_set = {f"{c['date']}|{c['time']}" for c in blocked_cells}
     display_blocked: set[str] = set()

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -2432,32 +2432,6 @@ def _expand_utc_dates(start_date: date, end_date: date) -> list[str]:
     return out
 
 
-def _expand_time_slots(start_time: str, end_time: str, slot_duration: int) -> list[str]:
-    """Return an ordered list of ``HH:MM`` slot strings, handling midnight wrap.
-
-    Args:
-        start_time: ``HH:MM`` start of the slot range.
-        end_time: ``HH:MM`` end of the slot range (exclusive). If less than or
-            equal to ``start_time``, wraps past midnight.
-        slot_duration: Slot length in minutes.
-
-    Returns:
-        List of ``HH:MM`` strings.
-
-    """
-    start = datetime.strptime(start_time, "%H:%M")
-    end = datetime.strptime(end_time, "%H:%M")
-    if end <= start:
-        end += timedelta(hours=24)
-    delta = timedelta(minutes=slot_duration)
-    out: list[str] = []
-    cur = start
-    while cur < end:
-        out.append(cur.strftime("%H:%M"))
-        cur += delta
-    return out
-
-
 @login_required
 @team_member_required()
 @require_POST
@@ -2526,7 +2500,6 @@ def availability_preview_view(request: HttpRequest, event_pk: int, squad_pk: int
         utc_blocked = list(blocked_cells)
 
     utc_dates = _expand_utc_dates(utc_start_date, utc_end_date)
-    utc_time_slots = _expand_time_slots(utc_start_time, utc_end_time, slot_duration)
 
     # 2. Convert UTC → display timezone (preferring the user's profile tz).
     user_tz = (getattr(request.user, "timezone", "") or "").strip()
@@ -2534,7 +2507,7 @@ def availability_preview_view(request: HttpRequest, event_pk: int, squad_pk: int
     if display_tz != "UTC" and display_tz not in available_timezones():
         display_tz = "UTC"
 
-    grid_data = convert_grid_to_local(utc_dates, utc_time_slots, utc_blocked, display_tz)
+    grid_data = convert_grid_to_local(utc_dates, utc_start_time, utc_end_time, slot_duration, utc_blocked, display_tz)
 
     return JsonResponse({
         "display_dates": list(grid_data["display_dates"]),
@@ -2835,7 +2808,7 @@ def availability_respond_view(request: HttpRequest, event_pk: int, squad_pk: int
     display_tz = user_tz or grid.grid_timezone or "UTC"
     tz_is_default = not user_tz
 
-    grid_data = convert_grid_to_local(grid.dates, grid.time_slots, grid.blocked_cells, display_tz)
+    grid_data = convert_grid_to_local(grid.dates, grid.start_time, grid.end_time, grid.slot_duration, grid.blocked_cells, display_tz)
 
     # Convert existing response UTC keys → local keys
     existing_local_keys: list[str] = []
@@ -2983,7 +2956,7 @@ def availability_results_view(request: HttpRequest, event_pk: int, squad_pk: int
     display_tz = user_tz or grid.grid_timezone or "UTC"
     tz_is_default = not user_tz
 
-    grid_data = convert_grid_to_local(grid.dates, grid.time_slots, grid.blocked_cells, display_tz)
+    grid_data = convert_grid_to_local(grid.dates, grid.start_time, grid.end_time, grid.slot_duration, grid.blocked_cells, display_tz)
 
     # Re-key user IDs from UTC → local
     cell_user_ids: dict[str, list[int]] = {}


### PR DESCRIPTION
The set of timeslots was set to be the same on each UTC day when displaying the form to riders, but this isn't how the form creation UI works: it sets the set of timeslots to be the same on each local day. Make the rider display match the form creation display by iterating from start_time to end_time on each UTC day in range.

This also fixes an issue introduced in a923e6b where the last few timeslots on the last day get cut off when going past midnight UTC.

Same change from #40, minus the parts that got pulled in as a923e6b, plus fixes from review and local testing.