### PR TITLE
Change Discord default auto_archive_duration to 3 days

### DIFF
--- a/apps/accounts/discord_service.py
+++ b/apps/accounts/discord_service.py
@@ -158,7 +158,7 @@ def send_discord_channel_message(
 def create_discord_thread(
     channel_id: str | int,
     name: str,
-    auto_archive_minutes: int = 1440,
+    auto_archive_minutes: int = 4320,
 ) -> tuple[int | None, str | None]:
     """Create a public thread in a Discord text channel.
 


### PR DESCRIPTION
This is the setting we have in the Coalition server for human-created threads, and it makes more sense for race threads which can go a few days between posts. The bot should match it.